### PR TITLE
Allow empty backslash line comments

### DIFF
--- a/syntax/forth.vim
+++ b/syntax/forth.vim
@@ -201,6 +201,7 @@ syn region forthString start=+c\"+ end=+"+ end=+$+ contains=@Spell
 
 " Comments
 syn match forthComment '\\\s.*$' contains=@Spell,forthTodo,forthSpaceError
+syn match forthComment '\\\%(\s.*\)\=$' contains=forthTodo,forthSpaceError
 syn region forthComment start='\\S\s' end='.*' contains=@Spell,forthTodo,forthSpaceError
 syn match forthComment '\.(\s[^)]*)' contains=@Spell,forthTodo,forthSpaceError
 syn region forthComment start='\(^\|\s\)\zs(\s' skip='\\)' end=')' contains=@Spell,forthTodo,forthSpaceError


### PR DESCRIPTION
Gforth makes use of these in block comments. E.g.,

```forth
\ Used Global Registers:
\
\ G0 used by DIV and MUL
\ G1 UP
```
