### PR TITLE
Remove highlighting of copyright lines in comments

### DIFF
--- a/syntax/forth.vim
+++ b/syntax/forth.vim
@@ -23,7 +23,6 @@ syn case ignore
 
 " Some special, non-FORTH keywords
 syn keyword forthTodo contained TODO FIXME XXX
-syn match forthTodo contained 'Copyright\(\s([Cc])\)\=\(\s[0-9]\{2,4}\)\='
 
 " Characters allowed in keywords
 " I don't know if 128-255 are allowed in ANS-FORTH


### PR DESCRIPTION
Only the first year in a list of years is currently highlighted.  Fixing
this to match all years is easy, however, it should probably extend to
the end of the copyright line which is impossible to reliably match.

Matching copyright lines is sufficiently unusual for a distributed
syntax file that it seems reasonable to just remove it.

If it's fixed it should probably have a dedicated syntax group linked to
SpecialComment rather than Todo.
