### PR TITLE
Highlight escape sequences in s-backslash-quote

### DIFF
--- a/syntax/forth.vim
+++ b/syntax/forth.vim
@@ -195,10 +195,10 @@ syn match forthFloat '\<-\=\d*[.]\=\d\+[DdEe][-+]\d\+\>'
 syn region forthComment start='0 \[if\]' end='\[endif\]' end='\[then\]' contains=forthTodo
 
 " Strings
-syn region forthString start=+\.*\"+ end=+"+ end=+$+ contains=@Spell
+syn region forthString start=+\.*"+ end=+"+ end=+$+ contains=@Spell
 " XXX
-syn region forthString start=+s\"+ end=+"+ end=+$+ contains=@Spell
-syn region forthString start=+c\"+ end=+"+ end=+$+ contains=@Spell
+syn region forthString start=+s"+ end=+"+ end=+$+ contains=@Spell
+syn region forthString start=+c"+ end=+"+ end=+$+ contains=@Spell
 
 syn region forthString matchgroup=forthString start=+s\\"+ end=+"+ end=+$+ contains=@Spell,forthEscape
 

--- a/syntax/forth.vim
+++ b/syntax/forth.vim
@@ -198,8 +198,12 @@ syn region forthComment start='0 \[if\]' end='\[endif\]' end='\[then\]' contains
 syn region forthString start=+\.*\"+ end=+"+ end=+$+ contains=@Spell
 " XXX
 syn region forthString start=+s\"+ end=+"+ end=+$+ contains=@Spell
-syn region forthString start=+s\\\"+ end=+"+ end=+$+ contains=@Spell
 syn region forthString start=+c\"+ end=+"+ end=+$+ contains=@Spell
+
+syn region forthString matchgroup=forthString start=+s\\"+ end=+"+ end=+$+ contains=@Spell,forthEscape
+
+syn match forthEscape +\\[abeflmnqrtvz"\\]+ contained
+syn match forthEscape "\\x\x\x" contained
 
 " Comments
 syn match forthComment '\\\%(\s.*\)\=$' contains=@Spell,forthTodo,forthSpaceError
@@ -243,6 +247,7 @@ hi def link forthCharOps Character
 hi def link forthConversion String
 hi def link forthForth Statement
 hi def link forthVocs Statement
+hi def link forthEscape Special
 hi def link forthString String
 hi def link forthComment Comment
 hi def link forthClassDef Define


### PR DESCRIPTION
- Highlight escape sequences in s-backslash-quote
- Remove unnecessary backslash-escaping in forthString patterns

We could highlight invalid hex escapes. The spec classifies this as an
"ambigious condition" and a quick check suggests it's handled differently by
the various implementations. E.g., VFX gives an error and Gforth ignores it.
