### PR TITLE
Fix runaway abort quote highlighting

### DIFF
--- a/syntax/forth.vim
+++ b/syntax/forth.vim
@@ -212,7 +212,7 @@ syn match forthComment '\.(\s[^)]*)' contains=@Spell,forthTodo,forthSpaceError
 syn region forthComment start='\(^\|\s\)\zs(\s' skip='\\)' end=')' contains=@Spell,forthTodo,forthSpaceError
 
 " Abort"
-syn region forthForth start=+ABORT"\s+ skip=+\\"+ end=+"+
+syn region forthForth start=+ABORT"\s+ end=+"+ end=+$+
 
 " Include files
 syn match forthInclude '^INCLUDE\s\+\k\+'

--- a/test.fs
+++ b/test.fs
@@ -171,6 +171,9 @@ char ( this-is-not-a-comment
 
 ABORT ABORT" message"
 
+ABORT" message
+not-continued-message
+
 \ --- Numbers
 
 123 #123 -123 #-123


### PR DESCRIPTION
Terminate ABORT" at the EOL if no closing " is found.