### PR TITLE
Set include and define options

### DIFF
--- a/ftplugin/forth.vim
+++ b/ftplugin/forth.vim
@@ -38,7 +38,7 @@ EOL
 let &l:define = $'\c\<\%({ s:define_patterns->join('\|') }\)'
 
 " assume consistent intra-project file extensions
-let &l:suffixesadd = expand("%:e")
+let &l:suffixesadd = "." .. expand("%:e")
 
 let b:undo_ftplugin = "setl cms< com< def< inc< isk< sua<"
 


### PR DESCRIPTION
- Set 'define' and 'include'
- Use a heredoc to build the b:match_words pattern

Using the heredoc to build the patterns is debatable.  To my eye, it's marginally easier to read.

This would be slightly cleaner in Vim9 script.
