### PR TITLE
Word boundaries are not required after parsing word delimiters

### DIFF
--- a/syntax/forth.vim
+++ b/syntax/forth.vim
@@ -202,11 +202,11 @@ syn match forthCharacter "'\k'"
 
 " Words that end with " are assumed to start string parsing.
 " This includes standard words: S" ."
-syn region forthString matchgroup=forthString start=+\<\S\+"\s+ end=+"\>+ end=+$+ contains=@Spell
+syn region forthString matchgroup=forthString start=+\<\S\+"\s+ end=+"+ end=+$+ contains=@Spell
   " extension words
-syn region forthString matchgroup=forthString start=+\<C"\s+ end=+"\>+ end=+$+ contains=@Spell
+syn region forthString matchgroup=forthString start=+\<C"\s+ end=+"+ end=+$+ contains=@Spell
 " Matches S\"
-syn region forthString matchgroup=forthString start=+\<S\\"\s+ end=+"\>+ end=+$+ contains=@Spell,forthEscape
+syn region forthString matchgroup=forthString start=+\<S\\"\s+ end=+"+ end=+$+ contains=@Spell,forthEscape
 
 syn match forthEscape +\C\\[abeflmnqrtvz"\\]+ contained
 syn match forthEscape "\C\\x\x\x" contained
@@ -223,11 +223,11 @@ syn match forthTodo contained "\<\%(TODO\|FIXME\|XXX\)\%(\>\|:\@=\)"
 syn region forthComment start='\<\%(0\|FALSE\)\s\+\[IF]' end='\<\[ENDIF]' end='\<\[THEN]' contains=forthTodo
 
 if get(g:, "forth_no_comment_fold", 0)
-    syn region forthComment start='\<(\>' end=')\>' contains=@Spell,forthTodo,forthSpaceError
+    syn region forthComment start='\<(\>' end=')' contains=@Spell,forthTodo,forthSpaceError
       " extension words
     syn match  forthComment '\<\\\>.*$' contains=@Spell,forthTodo,forthSpaceError
 else
-    syn region forthComment start='\<(\>' end=')\>' contains=@Spell,forthTodo,forthSpaceError fold
+    syn region forthComment start='\<(\>' end=')' contains=@Spell,forthTodo,forthSpaceError fold
       " extension words
     syn match  forthComment '\<\\\>.*$' contains=@Spell,forthTodo,forthSpaceError
     syn region forthMultilineComment start="^\s*\\\>" end="\n\%(\s*\\\>\)\@!" contains=forthComment transparent fold

--- a/syntax/forth.vim
+++ b/syntax/forth.vim
@@ -234,7 +234,7 @@ else
 endif
 
   " extension words
-syn match forthComment '\<\.(\s[^)]*)\>' contains=@Spell,forthTodo,forthSpaceError
+syn region forthComment start='\<\.(\>' end=')' end='$' contains=@Spell,forthTodo,forthSpaceError
 
 " ABORT {{{2
 syn keyword forthForth ABORT

--- a/test.fs
+++ b/test.fs
@@ -24,6 +24,10 @@ FALSE [IF] comment [THEN]
 \ Execute: :set foldmethod=syntax
 \  Result: These three lines should be folded.
 
+\ Verify that comments terminate at the closing ) delimiter.
+( paren)foo
+.( dot-paren)foo
+
 \ --- Strings
 
 \ Verify that strings have their own color.
@@ -38,6 +42,13 @@ S\" \a\b\e\f\l\m\n\q\r\t\v\z\"\xff\x00\\"
 
 \ Upper-case characters cannot be escaped.
 S\" \A\B\E\F\L\M\N\Q\R\T\V\Z\Xff\X00"
+
+\ Verify that strings terminate at the closing " delimiter.
+S" s-quote"foo
+C" c-quote"foo
+S\" s-backslash-quote"foo
+." dot-quote"foo
+CUSTOM" custom string matching word"foo
 
 \ --- Characters
 


### PR DESCRIPTION
E.g., S" s-quote"type is valid syntax and the string should terminate at the closing quote delimiter.

With this patch the following word will not be highlighted as syn-keyword, by definition, matches with a word-boundary at the beginning of each keyword.

We can fix this properly by only requiring a trailing word-boundary for words. This would require using syn-patterns for all words but could be done reasonably cleanly with a custom syntax command.
